### PR TITLE
A way of making the release tags lightweight

### DIFF
--- a/make-tag.rb
+++ b/make-tag.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# A perhaps rather overkill script to remove the dev stuff (DISCARDS)
+# from tags, so that the action is nice and lightweight when in use.
+
+require 'English'
+
+DISCARDS = %w[
+  .github
+  .rubocop.yml
+  .ruby-version
+  Gemfile
+  Gemfile.lock
+  make-tag.rb
+  spec
+  vendor
+].freeze
+
+version = ARGV.first
+raise 'Usage: ./make-tag.rb vMAJOR.MINOR.PATCH' unless ARGV.count == 1 && version.match?(/^v(\d+)\.(\d+)\.(\d+)$/)
+
+_ = `git rev-parse --verify refs/tags/#{version} 2>/dev/null`
+raise 'Tag already exists' if $CHILD_STATUS.success?
+
+root_tree = `git ls-tree -z HEAD:`.split("\0")
+$CHILD_STATUS.success? or exit 1
+
+root_tree.reject! do |entry|
+  m = entry.match(/\A\d+\s+\w+\s+\w+\t(.*)\z/)
+  m && DISCARDS.include?(m[1])
+end
+
+require 'tempfile'
+tree_id = Tempfile.open do |stdin|
+  Tempfile.open do |stdout|
+    root_tree.each { |entry| stdin.write("#{entry}\0") }
+    stdin.flush
+    stdin.rewind
+
+    system 'git mktree -z', in: stdin.fileno, out: stdout.fileno
+    $CHILD_STATUS.success? or exit 1
+
+    stdout.rewind
+    stdout.read.chomp
+  end
+end
+
+commit = `git commit-tree -p HEAD -m 'make-tag #{version}' #{tree_id}`.chomp
+$CHILD_STATUS.success? or exit 1
+
+system "git tag #{version} #{commit}"
+$CHILD_STATUS.success? or exit 1
+
+puts "Created tag #{version} -> #{commit}"


### PR DESCRIPTION
### Description

Addresses the problem described in the PR description of #6 - remove all the dev stuff (gems, tests, etc) when making tag, so that the action is lightweight.

This might be a silly idea. That's what you get in the quiet week leading up to Easter.

### References

* https://zendesk.atlassian.net/browse/XX-XXX

### Risks

<!--
Please apply exactly one of the risk labels:

* risk:none (only appropriate for PRs which don't affect what gets deployed, e.g. the README)
* risk:low
* risk:medium
* risk:high

The levels of risk are defined here: https://zendesk.atlassian.net/wiki/spaces/ENG/pages/92897648/Risks+in+Pull+Requests
-->

Non-deployed files

