### PR TITLE
Test on multiple rubies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,19 @@ jobs:
   test:
     name: rubocop and rspec
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
     steps:
       - uses: zendesk/checkout@v2
       - uses: zendesk/setup-ruby@v1.48.0
         with:
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rubocop && bundle exec rspec -f d

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           - '3.1'
     steps:
       - uses: zendesk/checkout@v2
-      - uses: zendesk/setup-ruby@v1.48.0
+      - uses: zendesk/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/repo_label_checker.rb
+++ b/repo_label_checker.rb
@@ -26,7 +26,9 @@ class RepoLabelChecker
     labels_in_repo = github_client.get("https://api.github.com/repos/#{repo_full_name}/labels?per_page=100")
     warn 'Warning: 100 labels found; there might be more. FIXME, pagination' if labels_in_repo.count >= 100
 
-    by_name = labels_in_repo.to_h { |label| [label.fetch('name'), label] }
+    # rubocop:disable Style/MapToHash - ruby 2.5 compat
+    by_name = labels_in_repo.map { |label| [label.fetch('name'), label] }.to_h
+    # rubocop:enable Style/MapToHash
 
     definitions.each do |name, (color, description)|
       existing = by_name[name]

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Runner do
       scenario.call
     ensure
       ENV.clear
-      ENV.merge!(old_env)
+      # Not using ENV.merge! because that's only in 2.7 onwards
+      old_env.each { |k, v| ENV[k] = v }
     end
   end
 


### PR DESCRIPTION
### Description

Ensure correction operation on various different rubies.

@sunesimonsen spotted that v1.0.0 was tripping up in guide-client with

```
repo_label_checker.rb:29:in `to_h': wrong element type Hash at 0 (expected array) (TypeError)
```

which turns out to be a problem that happens with ruby 2.5. We're only using `Array#to_h` because rubocop requires it - the code I originally wrote was `Array#map { ... }.to_h`, which is what we've now gone back to.

Also a similar fix for `ENV.merge!`.

### References

* https://zendesk.atlassian.net/browse/XX-XXX

### Risks

<!--
Please apply exactly one of the risk labels:

* risk:none (only appropriate for PRs which don't affect what gets deployed, e.g. the README)
* risk:low
* risk:medium
* risk:high

The levels of risk are defined here: https://zendesk.atlassian.net/wiki/spaces/ENG/pages/92897648/Risks+in+Pull+Requests
-->

Non-deployed files.

### Rollback plan

<!--
  Update in case the Rollback plan is more complex, e.g. failed backfills, kafka topic migrations, etc.
-->

1. Quickly roll back to the prior release.
2. Revert this PR to restore the master branch to a deployable green state.
3. Notify the author (unless the author is you).
