### PR TITLE
Don't crash if the PR's body is empty (nil)

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -49,7 +49,7 @@ class Runner
   def ensure_template_text_removed(text:, message:)
     pr_description = event.fetch('pull_request').fetch('body')
 
-    error(message) if pr_description.include?(text)
+    error(message) if pr_description&.include?(text)
   end
 
   def run

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -113,6 +113,12 @@ RSpec.describe Runner do
       ENV['ENSURE_TEMPLATE_TEXT_REMOVED_TEXT'] = 'foo'
       expect_success
     end
+
+    it 'passes if the event has no body' do
+      ENV['ENSURE_TEMPLATE_TEXT_REMOVED_TEXT'] = 'foo'
+      event['pull_request']['body'] = nil
+      expect_success
+    end
   end
 
   describe 'ENSURE_PR_IS_LABELLED' do


### PR DESCRIPTION
### Description

One can debate whether the "template text removed" check should _fail_ if the PR body is entirely empty, but the check should in any case not _crash_.

### References

* https://github.com/zendesk/help_center/actions/runs/3822510465/jobs/6502722077


