### PR TITLE
Add dependabot config to run weekly checks for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: "bundler"
+    vendor: true
+    directory: "/"
+    labels:
+      - dependencies
+      - ruby
+      - risk:low
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    reviewers:
+      - "zendesk/aster"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
### Description

Add dependabot config to run weekly checks for version updates

### Risks

* risk:none (only appropriate for PRs which don't affect what gets deployed, e.g. the README)

### Rollback plan

1. Quickly roll back to the prior release.
2. Revert this PR to restore the master branch to a deployable green state.
3. Notify the author (unless the author is you).
