### PR TITLE
Add default value for DEBUG_CREDENTIALS_PATH env variable

### DIFF
--- a/github_client.rb
+++ b/github_client.rb
@@ -28,7 +28,7 @@ class GithubClient
     uri = URI.parse(url)
     req = klass.new(uri)
 
-    req['Authorization'] = if (file = ENV.fetch('DEBUG_CREDENTIALS_PATH'))
+    req['Authorization'] = if (file = ENV.fetch('DEBUG_CREDENTIALS_PATH', nil))
                              "Basic #{[user_and_password(file)].pack('m0')}"
                            else
                              "Bearer #{ENV.fetch('GITHUB_TOKEN')}"


### PR DESCRIPTION
### Description
A default value for `DEBUG_CREDENTIALS_PATH` variable should be provided so that in case the value does not exist, the code doesn't throw an exception.

### References

* https://zendesk.atlassian.net/browse/KIAW-2242

### Risks

<!--
Please apply exactly one of the risk labels:

* risk:none (only appropriate for PRs which don't affect what gets deployed, e.g. the README)
* risk:low
* risk:medium
* risk:high

The levels of risk are defined here: https://zendesk.atlassian.net/wiki/spaces/ENG/pages/92897648/Risks+in+Pull+Requests
-->

* risk:low

### Rollback plan

<!--
  Update in case the Rollback plan is more complex, e.g. failed backfills, kafka topic migrations, etc.
-->

1. Quickly roll back to the prior release.
2. Revert this PR to restore the master branch to a deployable green state.
3. Notify the author (unless the author is you).
