### PR TITLE
Add optional auto risk label application [ai]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 # check-risk-label
+## v2.0.3
+* Add an `auto_apply_label` flag to parse the PR `### Risks` section and apply the matching `risk:*` label
+
 ## v2.0.2
 * Upgrade Ruby version of the action to v3.4
 
@@ -27,4 +30,3 @@
 ## v0.1.0 = v0.1
 
  * First release
-

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A custom Github Action for use on pull requests. The action:
 
 All three are optional. See 'Inputs'.
 
+`auto_apply_label` is also available if you want this action to parse the PR body's `### Risks`
+section and manage the matching `risk:*` label automatically.
+
 ## Inputs
 
 See `inputs` in [action.yml](https://github.com/zendesk/check-risk-label/blob/main/action.yml).
@@ -38,3 +41,12 @@ jobs:
 
 where VERSION is the version you wish you use, e.g. `v1` (or a branch, or a commit hash).
 Check the top of this readme to find the latest release.
+
+To auto-apply the risk label from the PR description:
+
+```yaml
+      - name: Check risk
+        uses: zendesk/check-risk-label@VERSION
+        with:
+          auto_apply_label: 'true'
+```

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Ensure that the pull request has exactly 1 risk label (true/false)'
     required: false
     default: 'true'
+  auto_apply_label:
+    description: 'Parse the PR `### Risks` section and automatically apply the matching risk label (true/false)'
+    required: false
+    default: 'false'
   ensure_template_text_removed_text:
     description: 'Text to ensure is not present in the pull request description (skipped if empty)'
     required: false
@@ -32,5 +36,6 @@ runs:
         ENSURE_LABELS_DEFINED: ${{ inputs.ensure_labels_defined }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         ENSURE_PR_IS_LABELLED: ${{ inputs.ensure_pr_is_labelled }}
+        AUTO_APPLY_LABEL: ${{ inputs.auto_apply_label }}
         ENSURE_TEMPLATE_TEXT_REMOVED_TEXT: ${{ inputs.ensure_template_text_removed_text }}
         ENSURE_TEMPLATE_TEXT_REMOVED_MESSAGE: ${{ inputs.ensure_template_text_removed_message }}

--- a/run.rb
+++ b/run.rb
@@ -7,6 +7,7 @@
 
 require 'net/http'
 require 'json'
+require 'uri'
 
 class Runner
   RISK_LABELS = {
@@ -17,6 +18,9 @@ class Runner
   }.freeze
 
   RISK_LABELS_RE = /\Arisk:(none|low|medium|high)\z/
+  RISK_SECTION_ERROR = 'Please ensure that the PR description contains a ' \
+                       '`### Risks` section with a line starting with one of ' \
+                       'the words `high`, `medium`, `low` or `none`.'
 
   def error(message)
     warn("ERROR: #{message}")
@@ -28,13 +32,68 @@ class Runner
   end
 
   def ensure_labels_present(strict:)
-    require_relative 'github_client'
     require_relative 'repo_label_checker'
-    RepoLabelChecker.new(event, GithubClient.new).run(strict: strict, definitions: RISK_LABELS)
+    RepoLabelChecker.new(event, github_client).run(strict: strict, definitions: RISK_LABELS)
   end
 
   def event
     @event ||= JSON.parse(File.read(ENV.fetch('GITHUB_EVENT_PATH')))
+  end
+
+  def github_client
+    require_relative 'github_client'
+    @github_client ||= GithubClient.new
+  end
+
+  def repo_full_name
+    event.fetch('repository').fetch('full_name')
+  end
+
+  def pr_number
+    event.fetch('number')
+  end
+
+  def issue_labels_url
+    "https://api.github.com/repos/#{repo_full_name}/issues/#{pr_number}/labels"
+  end
+
+  def issue_label_url(label_name)
+    "#{issue_labels_url}/#{URI.encode_www_form_component(label_name)}"
+  end
+
+  def risk_from_pr_body
+    pr_body = event.fetch('pull_request').fetch('body')
+    return nil if pr_body.nil?
+
+    risk_section = pr_body.lines.drop_while { |line| line !~ /^###\s+Risks\b/i }.join
+    return nil if risk_section.empty?
+
+    uncommented_risk_section = risk_section.gsub(/<!--.*?-->/m, '')
+
+    %w[high medium low none].find do |risk|
+      uncommented_risk_section.lines.any? { |line| line.match?(/^\W*#{risk}\b/i) }
+    end
+  end
+
+  def auto_apply_risk_label
+    desired_risk = risk_from_pr_body
+
+    if desired_risk.nil?
+      error(RISK_SECTION_ERROR)
+      return
+    end
+
+    desired_label = "risk:#{desired_risk}"
+    labels_on_pr = event.fetch('pull_request').fetch('labels').map { |label| label.fetch('name') }
+    risk_labels_on_pr = labels_on_pr.grep(RISK_LABELS_RE)
+    stale_risk_labels = risk_labels_on_pr - [desired_label]
+
+    stale_risk_labels.each { |label| github_client.delete(issue_label_url(label)) }
+    github_client.post(issue_labels_url, { labels: [desired_label] }) unless risk_labels_on_pr.include?(desired_label)
+
+    updated_labels = labels_on_pr - stale_risk_labels
+    updated_labels << desired_label unless updated_labels.include?(desired_label)
+    event.fetch('pull_request')['labels'] = updated_labels.map { |label| { 'name' => label } }
   end
 
   def ensure_one_label_applied
@@ -63,13 +122,18 @@ class Runner
     error('ensure_pr_is_labelled must be one of: true, false') \
       unless %w[true false].include?(ensure_pr_is_labelled)
 
+    auto_apply_label = ENV.fetch('AUTO_APPLY_LABEL')
+    error('auto_apply_label must be one of: true, false') \
+      unless %w[true false].include?(auto_apply_label)
+
     ensure_template_text_removed_text = ENV.fetch('ENSURE_TEMPLATE_TEXT_REMOVED_TEXT')
     ensure_template_text_removed_message = ENV.fetch('ENSURE_TEMPLATE_TEXT_REMOVED_MESSAGE')
 
     abort_if_errors
 
     ensure_labels_present(strict: ensure_labels_defined == 'strict') unless ensure_labels_defined == 'false'
-    ensure_one_label_applied if ensure_pr_is_labelled
+    auto_apply_risk_label if auto_apply_label == 'true'
+    ensure_one_label_applied if ensure_pr_is_labelled == 'true'
     unless ensure_template_text_removed_text == ''
       ensure_template_text_removed(text: ensure_template_text_removed_text,
                                    message: ensure_template_text_removed_message)

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Runner do
     ENV['ENSURE_LABELS_DEFINED'] = 'strict'
     ENV['GITHUB_TOKEN'] = 'a-token'
     ENV['ENSURE_PR_IS_LABELLED'] = 'true'
+    ENV['AUTO_APPLY_LABEL'] = 'false'
     ENV['ENSURE_TEMPLATE_TEXT_REMOVED_TEXT'] = ''
     ENV['ENSURE_TEMPLATE_TEXT_REMOVED_MESSAGE'] = 'Oh no!'
 
@@ -66,6 +67,12 @@ RSpec.describe Runner do
     ENV['ENSURE_PR_IS_LABELLED'] = 'well this is awkward'
 
     expect_failure('ERROR: ensure_pr_is_labelled must be one of: true, false')
+  end
+
+  it 'validates AUTO_APPLY_LABEL' do
+    ENV['AUTO_APPLY_LABEL'] = 'well this is awkward'
+
+    expect_failure('ERROR: auto_apply_label must be one of: true, false')
   end
 
   describe 'ENSURE_LABELS_DEFINED' do
@@ -127,6 +134,12 @@ RSpec.describe Runner do
       ENV['ENSURE_TEMPLATE_TEXT_REMOVED_TEXT'] = ''
     end
 
+    it 'respects false' do
+      ENV['ENSURE_PR_IS_LABELLED'] = 'false'
+      event['pull_request']['labels'] = []
+      expect_success
+    end
+
     it 'fails if there are no risk labels' do
       event['pull_request']['labels'] = [{ 'name' => 'risk:not_a_recognised_label' }]
       expect_failure('ERROR: Please apply exactly one of the risk labels: risk:none, risk:low, risk:medium, risk:high')
@@ -140,6 +153,90 @@ RSpec.describe Runner do
     it 'fails if there are multiple risk labels' do
       event['pull_request']['labels'] = [{ 'name' => 'risk:low' }, { 'name' => 'risk:high' }]
       expect_failure('ERROR: Please apply exactly one of the risk labels: risk:none, risk:low, risk:medium, risk:high')
+    end
+  end
+
+  describe 'AUTO_APPLY_LABEL' do
+    before do
+      ENV['ENSURE_LABELS_DEFINED'] = 'false'
+      ENV['ENSURE_PR_IS_LABELLED'] = 'true'
+      ENV['AUTO_APPLY_LABEL'] = 'true'
+      ENV['ENSURE_TEMPLATE_TEXT_REMOVED_TEXT'] = ''
+      event['pull_request']['labels'] = [
+        { 'name' => 'needs-review' },
+        { 'name' => 'risk:low' },
+        { 'name' => 'risk:none' }
+      ]
+    end
+
+    it 'skips if disabled' do
+      ENV['AUTO_APPLY_LABEL'] = 'false'
+      event['pull_request']['labels'] = [{ 'name' => 'risk:none' }]
+      expect(github_client).not_to receive(:delete)
+      expect(github_client).not_to receive(:post)
+      expect_success
+    end
+
+    it 'removes stale risk labels and adds the parsed one' do
+      event['pull_request']['body'] = <<~BODY
+        ### Summary
+        change
+
+        ### Risks
+        medium
+      BODY
+
+      expect(github_client).to receive(:delete).with('https://api.github.com/repos/zendesk/check-risk-label/issues/4/labels/risk%3Alow')
+      expect(github_client).to receive(:delete).with('https://api.github.com/repos/zendesk/check-risk-label/issues/4/labels/risk%3Anone')
+      expect(github_client).to receive(:post).with(
+        'https://api.github.com/repos/zendesk/check-risk-label/issues/4/labels',
+        { labels: ['risk:medium'] }
+      )
+
+      expect_success
+    end
+
+    it 'does not re-add a label that is already correct' do
+      event['pull_request']['body'] = <<~BODY
+        ### Risks
+        high
+      BODY
+      event['pull_request']['labels'] = [{ 'name' => 'risk:high' }, { 'name' => 'risk:low' }]
+
+      expect(github_client).to receive(:delete).with('https://api.github.com/repos/zendesk/check-risk-label/issues/4/labels/risk%3Alow')
+      expect(github_client).not_to receive(:post)
+
+      expect_success
+    end
+
+    it 'ignores commented-out risk lines' do
+      event['pull_request']['body'] = <<~BODY
+        ### Risks
+        <!--
+        high
+        -->
+        low
+      BODY
+      event['pull_request']['labels'] = []
+
+      expect(github_client).to receive(:post).with(
+        'https://api.github.com/repos/zendesk/check-risk-label/issues/4/labels',
+        { labels: ['risk:low'] }
+      )
+
+      expect_success
+    end
+
+    it 'fails if the PR body does not contain a parseable risk section' do
+      event['pull_request']['body'] = 'No risk heading here'
+
+      expect(github_client).not_to receive(:delete)
+      expect(github_client).not_to receive(:post)
+
+      expect_failure(
+        "ERROR: #{Runner::RISK_SECTION_ERROR}",
+        'ERROR: Please apply exactly one of the risk labels: risk:none, risk:low, risk:medium, risk:high'
+      )
     end
   end
 


### PR DESCRIPTION
> [!CAUTION] 
> This is being 100% vibe coded. 🚀  

### Description

### References

* https://zendesk.atlassian.net/browse/XX-XXX

### Risks

<!--
Please apply exactly one of the risk labels:

* risk:none (only appropriate for PRs which don't affect what gets deployed, e.g. the README)
* risk:low
* risk:medium
* risk:high

The levels of risk are defined here: https://zendesk.atlassian.net/wiki/spaces/ENG/pages/92897648/Risks+in+Pull+Requests
-->

Please remove this text and replace it with a rationale for the selected risk level.

### Rollback plan

<!--
  Update in case the Rollback plan is more complex, e.g. failed backfills, kafka topic migrations, etc.
-->

1. Quickly roll back to the prior release.
2. Revert this PR to restore the master branch to a deployable green state.
3. Notify the author (unless the author is you).
